### PR TITLE
Show errors the same as any other return value

### DIFF
--- a/autoload/jupyterkernel.vim
+++ b/autoload/jupyterkernel.vim
@@ -84,6 +84,8 @@ function! s:handle_result(ch, msg) abort
                 " Extract output
                 if l:msg_dict['msg_type'] == 'execute_result'
                     let l:output = l:msg_dict['content']['data']['text/plain']
+                elseif l:msg_dict['msg_type'] == 'error'
+                    let l:output = insert(l:msg_dict['content']['traceback'], l:msg_dict['content']['ename'])
                 else
                     let l:output = l:msg_dict['content']['text']
                 endif


### PR DESCRIPTION
When there was any sort of error in my python code I would get an error in vim with no indication on what the error was.
This change prints the traceback the same as any other return value (the same as in regular jupyter notebooks).
Additionally I added a function to strip the ansi escape codes from the traceback since vim doesn't use them to color anyways.

Error I was seeing
![image](https://user-images.githubusercontent.com/2179547/54787458-5eba9b00-4bf1-11e9-94ae-a3f78c57ff41.png)

Now what I see
![image](https://user-images.githubusercontent.com/2179547/54787473-742fc500-4bf1-11e9-8cb7-b4fb7570ca02.png)

This is my first pull request to this repo, so please let me know if I can prepare things better for you.